### PR TITLE
Fix Fudge dice handling for multi-die rolls

### DIFF
--- a/__tests__/roller.test.ts
+++ b/__tests__/roller.test.ts
@@ -1,6 +1,7 @@
 import { DiceRoller } from '../src/roller/dice-roller';
 import { DiceExpression } from '../src/types';
 import { randomInt } from 'crypto';
+import { DiceNotationParser } from '../src/parser/dice-notation-parser';
 
 // Mock the crypto module
 jest.mock('crypto', () => ({
@@ -12,6 +13,7 @@ const mockedRandomInt = randomInt as jest.Mock;
 
 describe('DiceRoller', () => {
   const roller = new DiceRoller();
+  const parser = new DiceNotationParser();
 
   beforeEach(() => {
     mockedRandomInt.mockClear();
@@ -164,5 +166,18 @@ describe('DiceRoller', () => {
     expect(result.rolls[0].rerolled).toBe(true);
     expect(result.rolls[0].modified).toBe(4);
     expect(result.rolls[1].rerolled).toBeUndefined();
+  });
+
+  test('rolls fudge dice correctly', () => {
+    const expression = parser.parse('3dF');
+
+    mockedRandomInt
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(1)
+      .mockReturnValueOnce(2);
+
+    const result = roller.roll('test', expression);
+    expect(result.rolls.map(r => r.result)).toEqual([-1, 0, 1]);
+    expect(result.total).toBe(0);
   });
 });

--- a/src/parser/dice-notation-parser.ts
+++ b/src/parser/dice-notation-parser.ts
@@ -81,6 +81,10 @@ export class DiceNotationParser {
           size,
         };
 
+        if (sizeStr === 'f') {
+          term.fudge = true;
+        }
+
         const keepDrop = diceMatch[3];
         const keepDropCount = diceMatch[4] ? parseInt(diceMatch[4], 10) : 1;
         if (keepDrop) {

--- a/src/roller/dice-roller.ts
+++ b/src/roller/dice-roller.ts
@@ -13,10 +13,12 @@ export class DiceRoller {
       const count = Math.abs(term.count);
 
       for (let i = 0; i < count; i++) {
-        let roll = randomInt(1, term.size + 1);
-        if (term.size === 1 && term.count === 1) {
-          // Fudge dice
-          roll = roll === 1 ? -1 : roll === 2 ? 0 : 1;
+        let roll: number;
+        if (term.fudge) {
+          // Fudge dice: uniform -1, 0, 1
+          roll = randomInt(0, 3) - 1;
+        } else {
+          roll = randomInt(1, term.size + 1);
         }
         const die: DieRoll = { size: term.size, result: roll };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export interface DiceExpression {
 export interface DiceTerm {
   count: number;
   size: number;
+  fudge?: boolean;
   explode?: boolean;
   reroll?: number[]; // reroll if in value
   keep?: { type: 'h' | 'l'; count: number };


### PR DESCRIPTION
## Summary
- correctly flag Fudge dice in the parser and types
- roll Fudge dice with uniform -1/0/+1 outcomes regardless of count
- add regression test for Fudge dice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68914ab41bd48331b720793a4618ffe8